### PR TITLE
[Astro-Tutorial] Fix message label

### DIFF
--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -56,7 +56,7 @@ if (Astro.request.method === "POST") {
 				</div>
 	
 				<div class="field">
-					<label for="email">Message:</label>
+					<label for="message">Message:</label>
 					<textarea name="message" rows="4" required></textarea>
 				</div>
 


### PR DESCRIPTION
The message label's `for` attribute was falsely set to `for="email"` (probably due to copy-paste from the email field above).

Fixed the label to actually target the `textarea name="message"` field.